### PR TITLE
Introduce type related utility functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "library",
     "license": "MIT",
     "autoload": {
+        "files": ["src/functions_include.php"],
         "psr-4": {
             "ipl\\Stdlib\\": "src"
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ipl\Stdlib;
+
+use InvalidArgumentException;
+use Traversable;
+use stdClass;
+
+/**
+ * Detect and return the PHP type of the given subject
+ *
+ * If subject is an object, the name of the object's class is returned, otherwise the subject's type.
+ *
+ * @param   $subject
+ *
+ * @return  string
+ */
+function get_php_type($subject)
+{
+    if (is_object($subject)) {
+        return get_class($subject);
+    } else {
+        return gettype($subject);
+    }
+}
+
+/**
+ * Get the array value of the given subject
+ *
+ * @param   array|object|Traversable   $subject
+ *
+ * @return  array
+ *
+ * @throws  InvalidArgumentException   If subject type is invalid
+ */
+function arrayval($subject)
+{
+    if (is_array($subject)) {
+        return $subject;
+    }
+
+    if ($subject instanceof stdClass) {
+        return (array) $subject;
+    }
+
+    if ($subject instanceof Traversable) {
+        // Works for generators too
+        return iterator_to_array($subject);
+    }
+
+    throw new InvalidArgumentException(sprintf(
+        'arrayval expects arrays, objects or instances of Traversable. Got %s instead.',
+        get_php_type($subject)
+    ));
+}

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,6 @@
+<?php
+
+// Don't redefine the functions if included multiple times
+if (! function_exists('ipl\Stdlib\get_php_type')) {
+    require __DIR__ . '/functions.php';
+}

--- a/tests/php/FunctionsTest.php
+++ b/tests/php/FunctionsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ipl\Tests\Stdlib;
+
+use ArrayIterator;
+use stdClass;
+use ipl\Stdlib;
+
+class FunctionsTest extends TestCase
+{
+    public function testGetPhpTypeWithObject()
+    {
+        $object = (object) [];
+
+        $this->assertSame('stdClass', Stdlib\get_php_type($object));
+    }
+
+    public function testGetPhpTypeWithInstance()
+    {
+        $instance = new stdClass();
+
+        $this->assertSame('stdClass', Stdlib\get_php_type($instance));
+    }
+
+    public function testGetPhpTypeWithPhpType()
+    {
+        $array = [];
+
+        $this->assertSame('array', Stdlib\get_php_type($array));
+    }
+
+    public function testArrayvalWithArray()
+    {
+        $array = ['key' => 'value'];
+
+        $this->assertSame($array, Stdlib\arrayval($array));
+    }
+
+    public function testArrayvalWithObject()
+    {
+        $array = ['key' => 'value'];
+
+        $object = (object) $array;
+
+        $this->assertSame($array, Stdlib\arrayval($object));
+    }
+
+    public function testArrayvalWithTraversable()
+    {
+        $array = ['key' => 'value'];
+
+        $traversable = new ArrayIterator($array);
+
+        $this->assertSame($array, Stdlib\arrayval($traversable));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testArrayvalException()
+    {
+        Stdlib\arrayval(null);
+    }
+}


### PR DESCRIPTION
Rationale:

```php
namespace ipl\Example;

use ipl\Stdlib;

class Example
{
    /**
       * @param mixed $data
       */
    public function values($data)
    {
        if (! Stdlib\is_foreachable($data)) {
            throw new \InvalidArgumentException(sprintf(
                'Expected traversable type. Got %s instead.',
                Stdlib\detect_type($data)
             ));
        }
    }
}
```

Right now we have `getPhpTypeName()` in `ipl-html` only but I think we could use this method in other places as well.