### PR TITLE
Use Contract namespace instead of Contracts

### DIFF
--- a/src/Contract/ValidatorInterface.php
+++ b/src/Contract/ValidatorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ipl\Stdlib\Contract;
+
+interface ValidatorInterface
+{
+    /**
+     * Get whether the given value is valid
+     *
+     * @param   mixed   $value
+     *
+     * @return  bool
+     */
+    public function isValid($value);
+
+    /**
+     * Get the validation error messages
+     *
+     * @return  array
+     */
+    public function getMessages();
+}

--- a/src/Contracts/ValidatorInterface.php
+++ b/src/Contracts/ValidatorInterface.php
@@ -2,18 +2,9 @@
 
 namespace ipl\Stdlib\Contracts;
 
-interface ValidatorInterface
+/**
+ * @deprecated Use {@link \ipl\Stdlib\Contract\ValidatorInterface} instead. We use the singular form for namespaces
+ */
+interface ValidatorInterface extends \ipl\Stdlib\Contract\ValidatorInterface
 {
-    /**
-     * Whether the given value is valid
-     *
-     * @param mixed $value
-     * @return bool
-     */
-    public function isValid($value);
-
-    /**
-     * @return array
-     */
-    public function getMessages();
 }


### PR DESCRIPTION
Because we use singular for namespaces.