### PR TITLE
Reference symbols from global space via FQN

### DIFF
--- a/src/Loader/AutoLoadingPluginLoader.php
+++ b/src/Loader/AutoLoadingPluginLoader.php
@@ -2,8 +2,6 @@
 
 namespace ipl\Stdlib\Loader;
 
-use InvalidArgumentException;
-
 class AutoLoadingPluginLoader implements PluginLoaderInterface
 {
     protected $namespace;
@@ -28,7 +26,7 @@ class AutoLoadingPluginLoader implements PluginLoaderInterface
         $instance = $this->eventuallyLoad($name);
 
         if ($instance === null) {
-            throw new InvalidArgumentException(\sprintf(
+            throw new \InvalidArgumentException(\sprintf(
                 'Unable to load %s (%s)',
                 $name,
                 $this->getFullClassByName($name)

--- a/src/Loader/AutoLoadingPluginLoader.php
+++ b/src/Loader/AutoLoadingPluginLoader.php
@@ -28,7 +28,7 @@ class AutoLoadingPluginLoader implements PluginLoaderInterface
         $instance = $this->eventuallyLoad($name);
 
         if ($instance === null) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Unable to load %s (%s)',
                 $name,
                 $this->getFullClassByName($name)
@@ -51,7 +51,7 @@ class AutoLoadingPluginLoader implements PluginLoaderInterface
     public function eventuallyGetClassByName($name)
     {
         $class = $this->getFullClassByName($name);
-        if (class_exists($class)) {
+        if (\class_exists($class)) {
             return $class;
         } else {
             return null;
@@ -76,7 +76,7 @@ class AutoLoadingPluginLoader implements PluginLoaderInterface
     public function getFullClassByName($name)
     {
         if ($this->uppercaseFirst) {
-            $name = ucfirst($name);
+            $name = \ucfirst($name);
         }
 
         return $this->namespace . '\\' . $name . $this->postfix;

--- a/src/Loader/PluginLoader.php
+++ b/src/Loader/PluginLoader.php
@@ -19,7 +19,7 @@ trait PluginLoader
         $plugin = $this->eventuallyLoadPlugin($type, $name);
 
         if ($plugin === null) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 'Could not load %s "%s"',
                 $type,
                 $name
@@ -78,7 +78,7 @@ trait PluginLoader
             $this->pluginLoaders[$type] = [];
         }
 
-        array_unshift($this->pluginLoaders[$type], $loader);
+        \array_unshift($this->pluginLoaders[$type], $loader);
 
         return $this;
     }

--- a/src/Loader/PluginLoader.php
+++ b/src/Loader/PluginLoader.php
@@ -2,8 +2,6 @@
 
 namespace ipl\Stdlib\Loader;
 
-use InvalidArgumentException;
-
 trait PluginLoader
 {
     /** @var array  */
@@ -19,7 +17,7 @@ trait PluginLoader
         $plugin = $this->eventuallyLoadPlugin($type, $name);
 
         if ($plugin === null) {
-            throw new InvalidArgumentException(\sprintf(
+            throw new \InvalidArgumentException(\sprintf(
                 'Could not load %s "%s"',
                 $type,
                 $name

--- a/src/Loader/PluginLoaderInterface.php
+++ b/src/Loader/PluginLoaderInterface.php
@@ -2,8 +2,6 @@
 
 namespace ipl\Stdlib\Loader;
 
-use InvalidArgumentException;
-
 interface PluginLoaderInterface
 {
     /**
@@ -22,7 +20,7 @@ interface PluginLoaderInterface
 
     /**
      * @param $name
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @return object
      */
     public function load($name);

--- a/src/MessageContainer.php
+++ b/src/MessageContainer.php
@@ -26,12 +26,12 @@ trait MessageContainer
      */
     public function addMessage($message)
     {
-        $args = func_get_args();
-        array_shift($args);
+        $args = \func_get_args();
+        \array_shift($args);
         if (empty($args)) {
             $this->messages[] = $message;
         } else {
-            $this->messages[] = vsprintf($message, $args);
+            $this->messages[] = \vsprintf($message, $args);
         }
 
         return $this;

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,10 +2,6 @@
 
 namespace ipl\Stdlib;
 
-use InvalidArgumentException;
-use Traversable;
-use stdClass;
-
 /**
  * Detect and return the PHP type of the given subject
  *
@@ -27,11 +23,11 @@ function get_php_type($subject)
 /**
  * Get the array value of the given subject
  *
- * @param   array|object|Traversable   $subject
+ * @param   array|object|\Traversable   $subject
  *
  * @return  array
  *
- * @throws  InvalidArgumentException   If subject type is invalid
+ * @throws  \InvalidArgumentException   If subject type is invalid
  */
 function arrayval($subject)
 {
@@ -39,16 +35,16 @@ function arrayval($subject)
         return $subject;
     }
 
-    if ($subject instanceof stdClass) {
+    if ($subject instanceof \stdClass) {
         return (array) $subject;
     }
 
-    if ($subject instanceof Traversable) {
+    if ($subject instanceof \Traversable) {
         // Works for generators too
         return \iterator_to_array($subject);
     }
 
-    throw new InvalidArgumentException(\sprintf(
+    throw new \InvalidArgumentException(\sprintf(
         'arrayval expects arrays, objects or instances of Traversable. Got %s instead.',
         get_php_type($subject)
     ));

--- a/src/functions.php
+++ b/src/functions.php
@@ -17,10 +17,10 @@ use stdClass;
  */
 function get_php_type($subject)
 {
-    if (is_object($subject)) {
-        return get_class($subject);
+    if (\is_object($subject)) {
+        return \get_class($subject);
     } else {
-        return gettype($subject);
+        return \gettype($subject);
     }
 }
 
@@ -35,7 +35,7 @@ function get_php_type($subject)
  */
 function arrayval($subject)
 {
-    if (is_array($subject)) {
+    if (\is_array($subject)) {
         return $subject;
     }
 
@@ -45,10 +45,10 @@ function arrayval($subject)
 
     if ($subject instanceof Traversable) {
         // Works for generators too
-        return iterator_to_array($subject);
+        return \iterator_to_array($subject);
     }
 
-    throw new InvalidArgumentException(sprintf(
+    throw new InvalidArgumentException(\sprintf(
         'arrayval expects arrays, objects or instances of Traversable. Got %s instead.',
         get_php_type($subject)
     ));

--- a/tests/php/FunctionsTest.php
+++ b/tests/php/FunctionsTest.php
@@ -2,8 +2,6 @@
 
 namespace ipl\Tests\Stdlib;
 
-use ArrayIterator;
-use stdClass;
 use ipl\Stdlib;
 
 class FunctionsTest extends TestCase
@@ -17,7 +15,7 @@ class FunctionsTest extends TestCase
 
     public function testGetPhpTypeWithInstance()
     {
-        $instance = new stdClass();
+        $instance = new \stdClass();
 
         $this->assertSame('stdClass', Stdlib\get_php_type($instance));
     }
@@ -49,7 +47,7 @@ class FunctionsTest extends TestCase
     {
         $array = ['key' => 'value'];
 
-        $traversable = new ArrayIterator($array);
+        $traversable = new \ArrayIterator($array);
 
         $this->assertSame($array, Stdlib\arrayval($traversable));
     }


### PR DESCRIPTION
PHP resolves relative function and constant references at call time. For each function call or access to a constant PHP checks whether the function or constant belongs to the current namespace or the global space. PHP7 introduces opcode optimizations which only apply for fully qualified name (FQN) calls.