### PR TITLE
Proper meta data for filters

### DIFF
--- a/src/Data.php
+++ b/src/Data.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace ipl\Stdlib;
+
+class Data
+{
+    /** @var array */
+    protected $data = [];
+
+    /**
+     * Check whether there's any data
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->data);
+    }
+
+    /**
+     * Check whether the given data exists
+     *
+     * @param string $name The name of the data
+     *
+     * @return bool
+     */
+    public function has($name)
+    {
+        return array_key_exists($name, $this->data);
+    }
+
+    /**
+     * Get the value of the given data
+     *
+     * @param string $name The name of the data
+     * @param mixed $default The value to return if there's no such data
+     *
+     * @return mixed
+     */
+    public function get($name, $default = null)
+    {
+        if ($this->has($name)) {
+            return $this->data[$name];
+        }
+
+        return $default;
+    }
+
+    /**
+     * Set the value of the given data
+     *
+     * @param string $name The name of the data
+     * @param mixed $value
+     *
+     * @return $this
+     */
+    public function set($name, $value)
+    {
+        $this->data[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Merge the given data
+     *
+     * @param Data $with
+     *
+     * @return $this
+     */
+    public function merge(self $with)
+    {
+        $this->data = array_merge($this->data, $with->data);
+
+        return $this;
+    }
+
+    /**
+     * Clear all data
+     *
+     * @return $this
+     */
+    public function clear()
+    {
+        $this->data = [];
+
+        return $this;
+    }
+}

--- a/src/Filter/Chain.php
+++ b/src/Filter/Chain.php
@@ -8,8 +8,9 @@ use ipl\Stdlib\Properties;
 use IteratorAggregate;
 use OutOfBoundsException;
 
-abstract class Chain implements Rule, IteratorAggregate, Countable
+abstract class Chain implements Rule, MetaDataProvider, IteratorAggregate, Countable
 {
+    use MetaData;
     use Properties;
 
     /** @var Rule[] */
@@ -28,10 +29,14 @@ abstract class Chain implements Rule, IteratorAggregate, Countable
     }
 
     /**
-     * Clone this chain's rules
+     * Clone this chain's meta data and rules
      */
     public function __clone()
     {
+        if ($this->metaData !== null) {
+            $this->metaData = clone $this->metaData;
+        }
+
         foreach ($this->rules as $i => $rule) {
             $this->rules[$i] = clone $rule;
         }

--- a/src/Filter/Chain.php
+++ b/src/Filter/Chain.php
@@ -4,14 +4,12 @@ namespace ipl\Stdlib\Filter;
 
 use ArrayIterator;
 use Countable;
-use ipl\Stdlib\Properties;
 use IteratorAggregate;
 use OutOfBoundsException;
 
 abstract class Chain implements Rule, MetaDataProvider, IteratorAggregate, Countable
 {
     use MetaData;
-    use Properties;
 
     /** @var Rule[] */
     protected $rules = [];

--- a/src/Filter/Condition.php
+++ b/src/Filter/Condition.php
@@ -2,12 +2,11 @@
 
 namespace ipl\Stdlib\Filter;
 
-use Exception;
-use InvalidArgumentException;
 use ipl\Stdlib\Properties;
 
-abstract class Condition implements Rule
+abstract class Condition implements Rule, MetaDataProvider
 {
+    use MetaData;
     use Properties;
 
     /** @var string */
@@ -26,6 +25,16 @@ abstract class Condition implements Rule
     {
         $this->setColumn($column)
             ->setValue($value);
+    }
+
+    /**
+     * Clone this condition's meta data
+     */
+    public function __clone()
+    {
+        if ($this->metaData !== null) {
+            $this->metaData = clone $this->metaData;
+        }
     }
 
     /**

--- a/src/Filter/Condition.php
+++ b/src/Filter/Condition.php
@@ -2,12 +2,9 @@
 
 namespace ipl\Stdlib\Filter;
 
-use ipl\Stdlib\Properties;
-
 abstract class Condition implements Rule, MetaDataProvider
 {
     use MetaData;
-    use Properties;
 
     /** @var string */
     protected $column;

--- a/src/Filter/MetaData.php
+++ b/src/Filter/MetaData.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ipl\Stdlib\Filter;
+
+use ipl\Stdlib\Data;
+
+trait MetaData
+{
+    /** @var Data */
+    protected $metaData;
+
+    public function metaData()
+    {
+        if ($this->metaData === null) {
+            $this->metaData = new Data();
+        }
+
+        return $this->metaData;
+    }
+}

--- a/src/Filter/MetaDataProvider.php
+++ b/src/Filter/MetaDataProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ipl\Stdlib\Filter;
+
+use ipl\Stdlib\Data;
+
+interface MetaDataProvider
+{
+    /**
+     * Get this rule's meta data
+     *
+     * @return Data
+     */
+    public function metaData();
+}

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ipl\Tests\Stdlib;
+
+use ipl\Stdlib\Data;
+
+class DataTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDataIsEmpty()
+    {
+        $data = new Data();
+
+        $this->assertTrue($data->isEmpty());
+    }
+
+    public function testDataHas()
+    {
+        $data = new Data();
+
+        $this->assertFalse($data->has('foo'));
+
+        $data->set('foo', 'bar');
+
+        $this->assertTrue($data->has('foo'));
+    }
+
+    public function testDataGet()
+    {
+        $data = new Data();
+
+        $this->assertNull($data->get('foo'));
+        $this->assertEquals('oof', $data->get('foo', 'oof'));
+
+        $data->set('foo', 'bar');
+
+        $this->assertEquals('bar', $data->get('foo'));
+    }
+
+    public function testDataMerge()
+    {
+        $data = new Data();
+
+        $toMerge = new Data();
+        $toMerge->set('foo', 'bar');
+
+        $this->assertNull($data->get('foo'));
+
+        $data->merge($toMerge);
+
+        $this->assertEquals('bar', $data->get('foo'));
+    }
+
+    public function testDataClear()
+    {
+        $data = new Data();
+        $data->set('foo', 'bar');
+
+        $this->assertFalse($data->isEmpty());
+
+        $data->clear();
+
+        $this->assertTrue($data->isEmpty());
+    }
+}


### PR DESCRIPTION
The `Properties` trait is not really what I imagined for filter meta data. Meta data, by definition, only consists of additional data that is not significant to how whatever it is related to, works. So it needs to be a separate object/interface. A separate interface is also one of the flaws I'd see of the `Properties` trait. When handling/defining filter meta data, I'd expect to be able to quickly identify the usages of said meta data. This doesn't work with dynamic anonymous *properties*.

This introduces the class `ipl\Stdlib\Data` which is more of a generic container for data. (Similar to the `ConfigObject` of Icinga Web 2)
Classes `ipl\Stdlib\Filter\Chain` and `ipl\Stdlib\Filter\Condition` implement a new interface `ipl\Stdlib\Filter\MetaDataProvider`.

General usage:
```php
$rule->metaData()->has('columnLabel');
$rule->metaData()->set('columnLabel', 'Host Name');
$rule->metaData()->get('columnLabel');
```