### PR TITLE
Allow to use cached iterator

### DIFF
--- a/src/Filter/Chain.php
+++ b/src/Filter/Chain.php
@@ -15,6 +15,9 @@ abstract class Chain implements Rule, MetaDataProvider, IteratorAggregate, Count
     /** @var Rule[] */
     protected $rules = [];
 
+    /** @var ArrayIterator */
+    protected $iterator;
+
     /**
      * Create a new Chain
      *
@@ -46,9 +49,13 @@ abstract class Chain implements Rule, MetaDataProvider, IteratorAggregate, Count
      *
      * @return ArrayIterator
      */
-    public function getIterator(): Traversable
+    public function getIterator(bool $fromCache = false): Traversable
     {
-        return new ArrayIterator($this->rules);
+        if (! $this->iterator || ! $this->iterator->valid() || ! $fromCache) {
+            $this->iterator = new ArrayIterator($this->rules);
+        }
+
+        return $this->iterator;
     }
 
     /**
@@ -61,6 +68,9 @@ abstract class Chain implements Rule, MetaDataProvider, IteratorAggregate, Count
     public function add(Rule $rule)
     {
         $this->rules[] = $rule;
+        if ($rule instanceof Condition) {
+            $rule->setChain($this);
+        }
 
         return $this;
     }

--- a/src/Filter/Condition.php
+++ b/src/Filter/Condition.php
@@ -2,6 +2,8 @@
 
 namespace ipl\Stdlib\Filter;
 
+use ipl\Stdlib\Filter;
+
 abstract class Condition implements Rule, MetaDataProvider
 {
     use MetaData;
@@ -11,6 +13,9 @@ abstract class Condition implements Rule, MetaDataProvider
 
     /** @var mixed */
     protected $value;
+
+    /** @var Chain */
+    protected $chain;
 
     /**
      * Create a new Condition
@@ -80,5 +85,23 @@ abstract class Condition implements Rule, MetaDataProvider
     public function getValue()
     {
         return $this->value;
+    }
+
+    /**
+     * @param Filter\Chain $chain
+     */
+    public function setChain(Filter\Chain $chain)
+    {
+        $this->chain = $chain;
+
+        return $this;
+    }
+
+    /**
+     * @return Filter\Chain
+     */
+    public function getChain()
+    {
+        return $this->chain;
     }
 }


### PR DESCRIPTION
This PR tries not to create a new iterator, as long it is not
explicitly requested to and the current iterator is still valid.