### PR TITLE
Str::symmetricSplit(): Make `$default` only accept `?string `

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -54,11 +54,11 @@ class Str
      * @param ?string $subject
      * @param string $delimiter
      * @param int    $limit
-     * @param mixed  $default
+     * @param ?string $default
      *
-     * @return array<int, mixed>
+     * @return array<int, ?string>
      */
-    public static function symmetricSplit(?string $subject, string $delimiter, int $limit, $default = null)
+    public static function symmetricSplit(?string $subject, string $delimiter, int $limit, ?string $default = null)
     {
         if ($subject === null || empty($delimiter)) {
             return array_pad([], $limit, $default);

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -54,7 +54,7 @@ class StrTest extends TestCase
 
     public function testSymmetricSplitReturnsArrayPaddedToTheSizeSpecifiedByLimitUsingCustomValue()
     {
-        $this->assertSame(['foo', 'bar', false, false], Str::symmetricSplit('foo,bar', ',', 4, false));
+        $this->assertSame(['foo', 'bar', 'default', 'default'], Str::symmetricSplit('foo,bar', ',', 4, 'default'));
     }
 
     public function testSymmetricSplitReturnsUnpaddedArrayIfTheSizeOfTheExplodedStringIsLessThanLimit()


### PR DESCRIPTION
After all, it is a Str-based class that should not pad anything other than string or null.

see: https://github.com/Icinga/icingaweb2-module-businessprocess/actions/runs/8466543979/job/23195516401?pr=446