### PR TITLE
Proposal: Add Str::limit method

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -90,4 +90,27 @@ class Str
 
         return array_map('trim', $exploded);
     }
+
+    /**
+     * Str::limit method truncates the given string to the specified length.
+     *
+     * This method will replace the truncated part with an ellipsis.
+     *
+     * @param   string  $subject
+     * @param   ?int    $limit Length of the string that will be returned
+     * @param   ?string $end Ellipsis that will be added to the truncated string
+     *
+     * @return  string
+     */
+    public static function limit(string $subject, ?int $limit = 50, ?string $end = '...'): string
+    {
+        // If the string is smaller or equal to the limit we simply return it
+        if (mb_strwidth($subject, 'UTF-8') <= $limit) {
+            return $subject;
+        }
+
+        // If the string is longer than the limit we truncate it
+        // and add the given end to it.
+        return mb_strimwidth($subject, 0, $limit, '', 'UTF-8') . $end;
+    }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -103,11 +103,17 @@ class StrTest extends TestCase
 
     public function testLimitWithLongerStringAndSpecificLimit()
     {
-        $this->assertSame('Lorem ipsu...', Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 10));
+        $this->assertSame(
+            'Lorem ipsu...',
+            Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 10)
+        );
     }
 
     public function testLimitWithLongerStringAndSpecificEnd()
     {
-        $this->assertSame('L (...)', Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 1, ' (...)'));
+        $this->assertSame(
+            'L (...)',
+            Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 1, ' (...)')
+        );
     }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -94,4 +94,20 @@ class StrTest extends TestCase
     {
         $this->assertSame(['foo', 'bar  , baz'], Str::trimSplit(' foo ,bar  , baz  ', ',', 2));
     }
+
+    public function testLimitWithSmallerString()
+    {
+        $this->assertSame('', Str::limit(''));
+        $this->assertSame('noop', Str::limit('noop'));
+    }
+
+    public function testLimitWithLongerStringAndSpecificLimit()
+    {
+        $this->assertSame('Lorem ipsu...', Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 10));
+    }
+
+    public function testLimitWithLongerStringAndSpecificEnd()
+    {
+        $this->assertSame('L (...)', Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 1, ' (...)'));
+    }
 }


### PR DESCRIPTION
This method truncates the given string to the specified length. Use cases are long titles and descriptions in text shown to the user, that would overload the screen.

Example:

```
$title = Str::limit('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 10);

$title == 'Lorem ipsu...';
```

I often find myself in need to truncate output such as titles and descriptions. Adding this to the stdlib would be nice, so it can be reused.

Might also be useful in existing Modules, for example:

![businessproc](https://github.com/user-attachments/assets/8ae70ad9-a4cd-4d6b-b1f7-9a7bd0a78ba3)
