### PR TITLE
Add strict type declarations to `Events::isValidEvent()`

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -74,7 +74,7 @@ trait Events
      *
      * @return bool
      */
-    public function isValidEvent($event)
+    public function isValidEvent(string $event): bool
     {
         return true;
     }


### PR DESCRIPTION
This breaking change requires adjustments to the following consumers:

ipl-html:
  - src/FormElement/FormElements.php

ipl-web:
  - src/Control/SearchBar.php

notifications-web:
  - library/Notifications/Web/Form/ContactForm.php

vspheredb:
  - library/Vspheredb/Web/Form/VCenterShipMetricsForm.php
  - library/Vspheredb/Web/Form/PerfdataConsumerForm.php