### PR TITLE
Drop `static` return type from `Events::on()`

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -43,7 +43,7 @@ trait Events
      *
      * @throws InvalidArgumentException If the event name is not valid
      */
-    public function on($event, callable $listener): static
+    public function on($event, callable $listener)
     {
         $this->assertValidEvent($event);
         $this->evenementUnvalidatedOn($event, $listener);


### PR DESCRIPTION
PHP enforces method signature compatibility when traits are combined in a
class hierarchy. Because `EventEmitterTrait` declares `on()` without a
return type, any subclass that inherits `on()` from a base using `Events`
and also uses `EventEmitterTrait` triggers a fatal error at load time due
to the conflicting `: static` annotation.

Dropping the return type makes `Events` composable alongside
`EventEmitterTrait` in shared class hierarchies.