### PR TITLE
Str extensions

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -2,6 +2,8 @@
 
 namespace ipl\Stdlib;
 
+use Stringable;
+
 /**
  * Collection of string manipulation functions
  */
@@ -89,5 +91,19 @@ class Str
         $exploded = $limit !== null ? explode($delimiter, $subject, $limit) : explode($delimiter, $subject);
 
         return array_map('trim', $exploded);
+    }
+
+    /**
+     * Check if the given string is empty
+     *
+     * Null is considered empty and strings are trimmed before checking.
+     *
+     * @param Stringable|string|null $subject
+     *
+     * @return bool
+     */
+    public static function isEmpty(Stringable|string|null $subject): bool
+    {
+        return $subject === null || trim((string) $subject) === '';
     }
 }

--- a/src/Str.php
+++ b/src/Str.php
@@ -87,6 +87,46 @@ class Str
     }
 
     /**
+     * Check if the given string contains any of the specified substrings
+     *
+     * @param ?string $haystack
+     * @param iterable<Stringable|string> $needles
+     * @param bool $caseSensitive
+     *
+     * @return bool
+     */
+    public static function containsAny(?string $haystack, iterable $needles, bool $caseSensitive = true): bool
+    {
+        foreach ($needles as $needle) {
+            if (self::contains($haystack, $needle, $caseSensitive)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the given string contains all the specified substrings
+     *
+     * @param ?string $haystack
+     * @param iterable<Stringable|string>[] $needles
+     * @param bool $caseSensitive
+     *
+     * @return bool
+     */
+    public static function containsAll(?string $haystack, iterable $needles, bool $caseSensitive = true): bool
+    {
+        foreach ($needles as $needle) {
+            if (! self::contains($haystack, $needle, $caseSensitive)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Split string into an array padded to the size specified by limit
      *
      * This method is a perfect fit if you need default values for symmetric array destructuring.

--- a/src/Str.php
+++ b/src/Str.php
@@ -68,6 +68,25 @@ class Str
     }
 
     /**
+     * Check if the given string contains the specified substring
+     *
+     * @param ?string $subject
+     * @param Stringable|string $needle
+     * @param bool $caseSensitive
+     *
+     * @return bool
+     */
+    public static function contains(?string $subject, Stringable|string $needle, bool $caseSensitive = true): bool
+    {
+        $subject ??= '';
+        if (! $caseSensitive) {
+            return str_contains(strtolower($subject), strtolower((string) $needle));
+        }
+
+        return str_contains($subject, (string) $needle);
+    }
+
+    /**
      * Split string into an array padded to the size specified by limit
      *
      * This method is a perfect fit if you need default values for symmetric array destructuring.

--- a/src/Str.php
+++ b/src/Str.php
@@ -49,6 +49,25 @@ class Str
     }
 
     /**
+     * Check if the given string ends with the specified substring
+     *
+     * @param ?string $subject
+     * @param string $end
+     * @param bool $caseSensitive
+     *
+     * @return bool
+     */
+    public static function endsWith(?string $subject, string $end, bool $caseSensitive = true): bool
+    {
+        $subject ??= '';
+        if (! $caseSensitive) {
+            return mb_strtolower(mb_substr($subject, -mb_strlen($end))) === mb_strtolower($end);
+        }
+
+        return str_ends_with($subject, $end);
+    }
+
+    /**
      * Split string into an array padded to the size specified by limit
      *
      * This method is a perfect fit if you need default values for symmetric array destructuring.

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -47,6 +47,51 @@ class StrTest extends TestCase
         $this->assertFalse(Str::startsWith('FOOBAR', 'foo', true));
     }
 
+    public function testEndsWithReturnsTrueIfStringEndsWithTheSpecifiedSubstring()
+    {
+        $this->assertTrue(Str::endsWith('config.ini', '.ini'));
+    }
+
+    public function testEndsWithReturnsFalseIfStringDoesNotEndWithTheSpecifiedSubstring()
+    {
+        $this->assertFalse(Str::endsWith('config.ini', '.php'));
+    }
+
+    public function testEndsWithReturnsTrueIfStringEndsWithTheSpecifiedSubstringAndCaseIsStrict()
+    {
+        $this->assertTrue(Str::endsWith('config.INI', '.INI', true));
+    }
+
+    public function testEndsWithReturnsFalseIfStringDoesNotEndWithTheSpecifiedSubstringAndCaseIsStrict()
+    {
+        $this->assertFalse(Str::endsWith('config.INI', '.ini', true));
+    }
+
+    public function testEndsWithReturnsTrueIfStringEndsWithTheSpecifiedSubstringCaseInsensitively()
+    {
+        $this->assertTrue(Str::endsWith('config.ini', '.INI', false));
+    }
+
+    public function testEndsWithReturnsFalseIfStringDoesNotEndWithTheSpecifiedSubstringCaseInsensitively()
+    {
+        $this->assertFalse(Str::endsWith('config.ini', '.PHP', false));
+    }
+
+    public function testEndsWithReturnsTrueForUtf8String()
+    {
+        $this->assertTrue(Str::endsWith('データベースへの接続に失敗しました', '失敗しました'));
+    }
+
+    public function testEndsWithReturnsFalseForUtf8StringWithWrongSuffix()
+    {
+        $this->assertFalse(Str::endsWith('データベースへの接続に失敗しました', '成功しました'));
+    }
+
+    public function testEndsWithReturnsTrueForUtf8StringCaseInsensitively()
+    {
+        $this->assertTrue(Str::endsWith('Der Schlüssel ist ungültig', 'UNGÜLTIG', false));
+    }
+
     public function testIsEmptyReturnsTrueForNull()
     {
         $this->assertTrue(Str::isEmpty(null));

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -92,6 +92,44 @@ class StrTest extends TestCase
         $this->assertTrue(Str::endsWith('Der Schlüssel ist ungültig', 'UNGÜLTIG', false));
     }
 
+    public function testContainsReturnsTrueIfStringContainsTheSpecifiedSubstring()
+    {
+        $this->assertTrue(Str::contains('MySQL server has gone away', 'server has gone away'));
+    }
+
+    public function testContainsReturnsFalseIfStringDoesNotContainTheSpecifiedSubstring()
+    {
+        $this->assertFalse(Str::contains('Query executed successfully', 'server has gone away'));
+    }
+
+    public function testContainsReturnsTrueIfStringContainsTheSpecifiedSubstringAndCaseIsStrict()
+    {
+        $this->assertTrue(Str::contains(
+            'Lost connection to MySQL server during query',
+            'Lost connection',
+            true,
+        ));
+    }
+
+    public function testContainsReturnsFalseIfStringDoesNotContainTheSpecifiedSubstringAndCaseIsStrict()
+    {
+        $this->assertFalse(Str::contains(
+            'lost connection to MySQL server during query',
+            'Lost connection',
+            true,
+        ));
+    }
+
+    public function testContainsReturnsTrueForUtf8String()
+    {
+        $this->assertTrue(Str::contains('データベースへの接続に失敗しました', '接続に失敗'));
+    }
+
+    public function testContainsReturnsFalseForUtf8StringWithWrongNeedle()
+    {
+        $this->assertFalse(Str::contains('データベースへの接続に失敗しました', '接続に成功'));
+    }
+
     public function testIsEmptyReturnsTrueForNull()
     {
         $this->assertTrue(Str::isEmpty(null));

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -47,6 +47,51 @@ class StrTest extends TestCase
         $this->assertFalse(Str::startsWith('FOOBAR', 'foo', true));
     }
 
+    public function testIsEmptyReturnsTrueForNull()
+    {
+        $this->assertTrue(Str::isEmpty(null));
+    }
+
+    public function testIsEmptyReturnsTrueForEmptyString()
+    {
+        $this->assertTrue(Str::isEmpty(''));
+    }
+
+    public function testIsEmptyReturnsTrueForStringWithLeadingAndTrailingWhitespace()
+    {
+        $this->assertTrue(Str::isEmpty('   '));
+    }
+
+    public function testIsEmptyReturnsTrueForStringWithOnlyWhitespace()
+    {
+        $this->assertTrue(Str::isEmpty("\t\n"));
+    }
+
+    public function testIsEmptyReturnsFalseForZero()
+    {
+        $this->assertFalse(Str::isEmpty('0'));
+    }
+
+    public function testIsEmptyReturnsFalseForNonEmptyString()
+    {
+        $this->assertFalse(Str::isEmpty('Warning'));
+    }
+
+    public function testIsEmptyReturnsFalseForStringWithContentAndSurroundingWhitespace()
+    {
+        $this->assertFalse(Str::isEmpty('  Warning  '));
+    }
+
+    public function testIsEmptyReturnsFalseForUtf8String()
+    {
+        $this->assertFalse(Str::isEmpty('接続エラー'));
+    }
+
+    public function testIsEmptyReturnsFalseForUtf8StringWithSurroundingWhitespace()
+    {
+        $this->assertFalse(Str::isEmpty('  接続エラー  '));
+    }
+
     public function testSymmetricSplitReturnsArrayPaddedToTheSizeSpecifiedByLimitUsingNullAsValueByDefault()
     {
         $this->assertSame(['foo', 'bar', null, null], Str::symmetricSplit('foo,bar', ',', 4));

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -140,6 +140,94 @@ class StrTest extends TestCase
         $this->assertFalse(Str::contains('データベースへの接続に失敗しました', '接続に成功'));
     }
 
+    public function testContainsAnyReturnsTrueIfStringContainsOneOfTheSpecifiedSubstrings()
+    {
+        $this->assertTrue(Str::containsAny('MySQL server has gone away', [
+            'server has gone away',
+            'Lost connection',
+            'Connection refused',
+        ]));
+    }
+
+    public function testContainsAnyReturnsFalseIfStringContainsNoneOfTheSpecifiedSubstrings()
+    {
+        $this->assertFalse(Str::containsAny('Query executed successfully', [
+            'server has gone away',
+            'Lost connection',
+            'Connection refused',
+        ]));
+    }
+
+    public function testContainsAnyReturnsTrueIfStringContainsOneOfTheSpecifiedSubstringsCaseInsensitively()
+    {
+        $this->assertTrue(Str::containsAny('LOST CONNECTION to MySQL server', [
+            'server has gone away',
+            'Lost connection',
+        ], false));
+    }
+
+    public function testContainsAnyReturnsFalseIfStringContainsNoneOfTheSpecifiedSubstringsAndCaseIsStrict()
+    {
+        $this->assertFalse(Str::containsAny('lost connection to MySQL server', [
+            'server has gone away',
+            'Lost connection',
+        ], true));
+    }
+
+    public function testContainsAnyReturnsTrueForUtf8String()
+    {
+        $this->assertTrue(Str::containsAny('データベースへの接続に失敗しました', ['タイムアウト', '接続に失敗']));
+    }
+
+    public function testContainsAnyReturnsFalseForUtf8StringWithWrongNeedles()
+    {
+        $this->assertFalse(Str::containsAny('データベースへの接続に失敗しました', ['タイムアウト', '接続に成功']));
+    }
+
+    public function testContainsAllReturnsTrueIfStringContainsAllSpecifiedSubstrings()
+    {
+        $this->assertTrue(Str::containsAll(
+            'host=db1.example.com;dbname=icingaweb2;charset=utf8',
+            ['host=', 'dbname=', 'charset='],
+        ));
+    }
+
+    public function testContainsAllReturnsFalseIfStringIsMissingOneOfTheSpecifiedSubstrings()
+    {
+        $this->assertFalse(Str::containsAll(
+            'host=db1.example.com;charset=utf8',
+            ['host=', 'dbname=', 'charset='],
+        ));
+    }
+
+    public function testContainsAllReturnsTrueIfStringContainsAllSpecifiedSubstringsCaseInsensitively()
+    {
+        $this->assertTrue(Str::containsAll(
+            'HOST=db1.example.com;DBNAME=icingaweb2',
+            ['host=', 'dbname='],
+            false,
+        ));
+    }
+
+    public function testContainsAllReturnsFalseIfStringIsMissingOneOfTheSpecifiedSubstringsAndCaseIsStrict()
+    {
+        $this->assertFalse(Str::containsAll(
+            'HOST=db1.example.com;DBNAME=icingaweb2',
+            ['host=', 'dbname='],
+            true,
+        ));
+    }
+
+    public function testContainsAllReturnsTrueForUtf8String()
+    {
+        $this->assertTrue(Str::containsAll('データベースへの接続に失敗しました', ['接続', '失敗']));
+    }
+
+    public function testContainsAllReturnsFalseForUtf8StringWithMissingNeedle()
+    {
+        $this->assertFalse(Str::containsAll('データベースへの接続に失敗しました', ['接続', '成功']));
+    }
+
     public function testIsEmptyReturnsTrueForNull()
     {
         $this->assertTrue(Str::isEmpty(null));

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -47,6 +47,16 @@ class StrTest extends TestCase
         $this->assertFalse(Str::startsWith('FOOBAR', 'foo', true));
     }
 
+    public function testStartsWithReturnsTrueForUtf8String()
+    {
+        $this->assertTrue(Str::startsWith('接続エラーが発生しました', '接続エラー'));
+    }
+
+    public function testStartsWithReturnsFalseForUtf8StringWithWrongPrefix()
+    {
+        $this->assertFalse(Str::startsWith('接続エラーが発生しました', 'エラーが'));
+    }
+
     public function testEndsWithReturnsTrueIfStringEndsWithTheSpecifiedSubstring()
     {
         $this->assertTrue(Str::endsWith('config.ini', '.ini'));


### PR DESCRIPTION
Add some static methods to the `Str` class.

- `endsWith` as the counterpart to the existing `startsWith`
- `contains` to have a case independent version of `str_contains`
- `containsAny` and `containsAll` to quickly compare against an array of strings