### PR TITLE
Seq: Fix that `find()` returns false instead of null

### DIFF
--- a/src/Seq.php
+++ b/src/Seq.php
@@ -37,7 +37,12 @@ class Seq
     {
         $usesCallback = $needle instanceof Closure;
         if (! $usesCallback && $caseSensitive && is_array($traversable)) {
-            return [array_search($needle, $traversable, true), $needle];
+            $result = array_search($needle, $traversable, true);
+
+            return match ($result) {
+                false   => [null, null],
+                default => [$result, $needle]
+            };
         }
 
         if (! $caseSensitive && is_string($needle) && ! $usesCallback) {

--- a/tests/SeqTest.php
+++ b/tests/SeqTest.php
@@ -18,6 +18,10 @@ class SeqTest extends TestCase
             ['foo', 'bar'],
             Seq::find(['foo' => 'bar', 'oof' => 'BAR'], 'BAR', false)
         );
+        $this->assertSame(
+            [null, null],
+            Seq::find(['foo' => 'bar', 'oof' => 'BAR'], 'missing')
+        );
     }
 
     public function testFindWithGenerators()


### PR DESCRIPTION
In case of arrays as array_search returns false.