### PR TITLE
Treat NUL bytes as empty in `Str::isEmpty()`

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -96,8 +96,8 @@ class Str
     /**
      * Check if the given string is empty
      *
-     * Null is considered empty, and strings consisting only of whitespace or visually
-     * empty characters are considered empty.
+     * Null is considered empty, and strings consisting only of whitespace, NUL bytes,
+     * or visually empty characters are considered empty.
      *
      * @param string|Stringable|null $subject
      *
@@ -105,6 +105,6 @@ class Str
      */
     public static function isEmpty(string|Stringable|null $subject): bool
     {
-        return $subject === null || preg_match('/^[\s\x{3164}\x{1160}]*$/u', $subject) === 1;
+        return $subject === null || preg_match('/^[\s\x00\x{3164}\x{1160}]*$/u', $subject) === 1;
     }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -67,6 +67,16 @@ class StrTest extends TestCase
         $this->assertTrue(Str::isEmpty("\t\n"));
     }
 
+    public function testIsEmptyReturnsTrueForNulByte()
+    {
+        $this->assertTrue(Str::isEmpty("\0"));
+    }
+
+    public function testIsEmptyReturnsTrueForNulByteCombinedWithWhitespace()
+    {
+        $this->assertTrue(Str::isEmpty("\0 "));
+    }
+
     public function testIsEmptyReturnsFalseForZero()
     {
         $this->assertFalse(Str::isEmpty('0'));


### PR DESCRIPTION
`Str::isEmpty()` now treats NUL bytes as empty, including when combined with whitespace or other accepted empty characters. The method contract and regression coverage document and verify the behavior.